### PR TITLE
Sorting so that it's easier to find an IP if you need to unblock it.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 unifi-doh-blocker
 config.toml
 *.json
+.DS_Store

--- a/unifi.go
+++ b/unifi.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"sort"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -273,6 +275,13 @@ func UnifiCreateFirewallGroup(url string, firewallGroup UnifiFirewallGroup) (Uni
 
 func UnifiUpdateFirewallGroup(url string, firewallGroup UnifiFirewallGroup) (UnifiFirewallGroupResponse, error) {
 	var firewallGroupResponse UnifiFirewallGroupResponse
+
+	// Sort IP addresses in numerical ascending order
+	sort.Slice(firewallGroup.GroupMembers, func(i, j int) bool {
+		ip1 := net.ParseIP(firewallGroup.GroupMembers[i])
+		ip2 := net.ParseIP(firewallGroup.GroupMembers[j])
+		return bytes.Compare(ip1, ip2) < 0
+	})
 
 	body, _ := json.Marshal(firewallGroup)
 


### PR DESCRIPTION
I added sorting so it’s easier to find a specific IP address in case you need to unblock it. I ran into this as the lists I’m using are blocking 7,000 IPs and one included Github’s IPs.

Thanks for this!